### PR TITLE
[Develop] Bash script to get hardware info and usage and insert into psql database

### DIFF
--- a/linux_sql/scripts/host_info.sh
+++ b/linux_sql/scripts/host_info.sh
@@ -9,7 +9,7 @@ psql_password=$5
 
 #Check # of CLI arguments passed. (echo msg and exit 1 if it's not equal to 5)
 if [ "$#" -ne 5 ]; then
-  echo "Illegal number of parameters"
+  echo "Illegal number of params"
   exit 1
 fi
 
@@ -17,7 +17,7 @@ fi
 hostname=$(hostname -f)
 lscpu_info=$(lscpu)
 
-#Put specific hardware information into variables
+#Put specific hardware information and timestamp into variables
 cpu_number=$(echo "$lscpu_info" | egrep "^CPU\(s\):" | awk '{print $2}' | xargs)
 cpu_architecture=$(echo "$lscpu_info" | egrep "^Architecture:" | awk '{print $2}' | xargs)
 cpu_model=$(echo "$lscpu_info" | egrep "^Model name:" | awk '{$1=$2=""; print $0}' | xargs)

--- a/linux_sql/scripts/host_info.sh
+++ b/linux_sql/scripts/host_info.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#Arguments: psql_host, psql_port, db_name, psql_user, psql_password
+psql_host=$1
+psql_port=$2
+db_name=$3
+psql_user=$4
+psql_password=$5
+
+#Check # of CLI arguments passed. (echo msg and exit 1 if it's not equal to 5)
+if [ "$#" -ne 5 ]; then
+  echo "Illegal number of parameters"
+  exit 1
+fi
+
+#Get overall hardware info and hostname and put into variables
+hostname=$(hostname -f)
+lscpu_info=$(lscpu)
+
+#Put specific hardware information into variables
+cpu_number=$(echo "$lscpu_info" | egrep "^CPU\(s\):" | awk '{print $2}' | xargs)
+cpu_architecture=$(echo "$lscpu_info" | egrep "^Architecture:" | awk '{print $2}' | xargs)
+cpu_model=$(echo "$lscpu_info" | egrep "^Model name:" | awk '{$1=$2=""; print $0}' | xargs)
+cpu_mhz=$(echo "$lscpu_info" | egrep "^(CPU MHz:)" | awk '{print $3}' | xargs)
+l2_cache=$(echo "$lscpu_info" | egrep "^(L2 cache:)" | awk '{print substr($3, 1, length($3)-1)}' | xargs)
+timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+total_mem=$(egrep '^MemTotal' /proc/meminfo | awk '{print $2}' | xargs)
+
+#Create PSQL command: Insert hardware info into host_info
+insert_fields="INSERT INTO host_info (hostname, cpu_number, cpu_architecture, cpu_model, cpu_mhz, l2_cache, timestamp, total_mem)"
+insert_values="VALUES('$hostname', $cpu_number, '$cpu_architecture', '$cpu_model', $cpu_mhz, $l2_cache, '$timestamp', $total_mem);"
+insert_stmt="$insert_fields$insert_values"
+
+#Set environment variable of password
+export PGPASSWORD=$psql_password
+
+#Insert data into database
+psql -h $psql_host -p $psql_port -d $db_name -U $psql_user -c "$insert_stmt"
+exit $?

--- a/linux_sql/scripts/host_usage.sh
+++ b/linux_sql/scripts/host_usage.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#Arguments: psql_host, psql_port, db_name, psql_user, psql_password
+psql_host=$1
+psql_port=$2
+db_name=$3
+psql_user=$4
+psql_password=$5
+
+#Check # of CLI arguments passed. (echo msg and exit 1 if it's not equal to 5)
+if [ "$#" -ne 5 ]; then
+  echo "Illegal number of params"
+  exit 1
+fi
+
+#Get hardware usage info and hostname and put into variables
+hostname=$(hostname -f)
+vmstat_mb=$(vmstat --unit M)
+
+#Put specific hardware usage info and timestamp into variables
+memory_free=$(echo "$vmstat_mb" | tail -1 | awk '{print $4}' | xargs)
+cpu_idle=$(echo "$vmstat_mb" | tail -1 | awk '{print $15}' | xargs)
+cpu_kernel=$(echo "$vmstat_mb" | tail -1 | awk '{print $14}' | xargs)
+disk_io=$(vmstat -d | tail -1 | awk '{print $10}' | xargs)
+disk_available=$(df -m | egrep "^.*/$" | awk '{print $4}' | xargs)
+timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+
+#Get the host_id
+host_id="(SELECT id FROM host_info WHERE hostname='$hostname')"
+
+#Create PSQL command: Insert hardware usage into host_usage
+insert_fields="INSERT INTO host_usage(timestamp, host_id, memory_free, cpu_idle, cpu_kernel, disk_io, disk_available)"
+insert_values="VALUES('$timestamp', $host_id, $memory_free, $cpu_idle, $cpu_kernel, $disk_io, $disk_available);"
+insert_stmt="$insert_fields$insert_values"
+
+#Set environment variable of password
+export PGPASSWORD=$psql_password
+
+#Insert data into database
+psql -h $psql_host -p $psql_port -d $db_name -U $psql_user -c "$insert_stmt"
+exit $?


### PR DESCRIPTION
This feature branch edits the blank bash script files (./linux_sql/scripts/host_info.sh) and (./linux_sql/scripts/host_usage.sh)

Both scripts take the arguments (psql_host, psql_port, db_name, psql_user, psql_password) to perform necessary operations.
Host_info
- use commands lscpu, hostname, date, etc. to get information of the systems hardware, name, and timestamp
- retrieve specific information and insert into variables
- create insert statement
- execute psql command with insert statement

Host_usage
- use commands vmstat, hostname, date, df. to get information of the systems hardware, name, timestamp, and disk
- retrieve specific information and insert into variables
- create insert statement
- execute psql command with insert statement
